### PR TITLE
ci: add image build + TS client publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,9 @@ ENV/
 .github/
 .gitignore
 
+# TypeScript client package (not needed in Python container)
+packages/
+
 # Testing
 .pytest_cache/
 .coverage

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,143 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main, dev, 'feat/**', 'fix/**']
+  workflow_dispatch:
+
+env:
+  ACR_REGISTRY: firebranddevet.azurecr.io
+  IMAGE_NAME: doc-proc-pymupdf
+  NODE_VERSION: "20"
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  build-and-push-image:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      image_tag: ${{ steps.get_version.outputs.image_tag }}
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version and set tag
+        id: get_version
+        run: |
+          VERSION=$(grep -oP 'version = "\K[^"]+' pyproject.toml)
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          BRANCH="${{ github.ref_name }}"
+
+          if [ "$BRANCH" = "main" ]; then
+            IMAGE_TAG="$VERSION"
+          elif [ "$BRANCH" = "dev" ]; then
+            IMAGE_TAG="${VERSION}-dev.${SHORT_SHA}"
+          else
+            SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9]/-/g')
+            IMAGE_TAG="${VERSION}-${SAFE_BRANCH}.${SHORT_SHA}"
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "Image tag: $IMAGE_TAG"
+
+      - name: Validate version uniqueness (main only)
+        if: github.ref_name == 'main'
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          echo "Checking if ${{ env.ACR_REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION} already exists..."
+          if docker pull "${{ env.ACR_REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}" 2>/dev/null; then
+            echo "Error: Image tag ${VERSION} already exists in registry."
+            echo "Increment the version in pyproject.toml before merging to main."
+            exit 1
+          fi
+          echo "Version ${VERSION} is available."
+
+      - name: Login to Azure Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.ACR_REGISTRY }}
+          username: firebranddevet
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Build and push image
+        run: |
+          IMAGE="${{ env.ACR_REGISTRY }}/${{ env.IMAGE_NAME }}"
+          TAG="${{ steps.get_version.outputs.image_tag }}"
+
+          docker build -t "${IMAGE}:${TAG}" .
+          docker push "${IMAGE}:${TAG}"
+
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            docker tag "${IMAGE}:${TAG}" "${IMAGE}:latest"
+            docker push "${IMAGE}:latest"
+          elif [ "${{ github.ref_name }}" = "dev" ]; then
+            docker tag "${IMAGE}:${TAG}" "${IMAGE}:dev"
+            docker push "${IMAGE}:dev"
+          fi
+
+  publish-client:
+    name: Publish TypeScript Client
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://npm.pkg.github.com
+          scope: '@firebrandanalytics'
+
+      - name: Install protoc
+        run: |
+          sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install client dependencies
+        working-directory: packages/client-ts
+        run: npm install
+
+      - name: Generate gRPC stubs
+        working-directory: packages/client-ts
+        run: |
+          chmod +x scripts/generate.sh
+          scripts/generate.sh
+
+      - name: Sync version from pyproject.toml
+        run: |
+          VERSION=$(grep -oP 'version = "\K[^"]+' pyproject.toml)
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          BRANCH="${{ github.ref_name }}"
+
+          if [ "$BRANCH" = "main" ]; then
+            PUBLISH_VERSION="$VERSION"
+          elif [ "$BRANCH" = "dev" ]; then
+            PUBLISH_VERSION="${VERSION}-dev.${SHORT_SHA}"
+          else
+            SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9]/-/g')
+            PUBLISH_VERSION="${VERSION}-${SAFE_BRANCH}.${SHORT_SHA}"
+          fi
+
+          cd packages/client-ts
+          npm version "$PUBLISH_VERSION" --no-git-tag-version --allow-same-version
+          echo "Publishing version: $PUBLISH_VERSION"
+
+      - name: Build TypeScript
+        working-directory: packages/client-ts
+        run: npm run build
+
+      - name: Publish to GitHub Packages
+        working-directory: packages/client-ts
+        run: |
+          BRANCH="${{ github.ref_name }}"
+          if [ "$BRANCH" = "main" ]; then
+            npm publish
+          else
+            npm publish --tag "$BRANCH"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds the missing CI workflow so this repo can build/push ACR images and
publish the TypeScript client to GitHub Packages on every push -- mirroring
the convention in `ff-services-doc-proc-pyworker`.

The repo currently has no `.github/workflows/`. The existing
`firebranddevet.azurecr.io/doc-proc-pymupdf:0.1.0` image was pushed manually.
This wires it up properly.

## Changes

- **`.github/workflows/deploy.yml`** (new) -- two jobs, mirrored 1:1 from
  `ff-services-doc-proc-pyworker`:
  - `build-and-push-image`: tags by `pyproject.toml` version + branch; main
    rejects duplicate tags, pushes `latest`; non-main pushes branch-suffixed
    tags.
  - `publish-client`: generates protobuf stubs, bumps version, publishes
    `@firebrandanalytics/pymupdf-worker-client` to `npm.pkg.github.com`.
- **`.dockerignore`** -- exclude `packages/` (TS client lives there and is
  not needed in the Python runtime image), matching pyworker.

## Required before merge

The repo needs an `ACR_PASSWORD` secret added at the GitHub repo settings
(or organization-level), pointing to the firebranddevet ACR push credential.
`pyworker` has this set; this repo does not yet.

```
gh secret set ACR_PASSWORD --repo firebrandanalytics/ff-services-pymupdf
```

## Test plan

- [ ] Add `ACR_PASSWORD` secret to repo
- [ ] Push a no-op commit to `feat/ci` -> the workflow runs; image is tagged
      `0.1.0-feat-ci.<sha>` and TS client `0.1.0-feat-ci.<sha>`
- [ ] Merge to main -> `0.1.0` already exists (manual push); CI rejects with
      "Increment the version in pyproject.toml before merging to main"
- [ ] Bump pyproject.toml to 0.1.1 -> CI succeeds, image `:0.1.1` and `:latest`
      published

Refs: WS#46 (RAG ingestion testing on financial PDFs)

Co-Authored-By: Claude Opus 4.7 (1M context)