### PR TITLE
fix: /api/render-region accepts multipart/form-data (WS#46 #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,41 +72,37 @@ Extract structured content from a PDF.
 ```
 
 ### `POST /api/render-region`
-Rasterize a bounding-box region of a single PDF page as a PNG image. Used by
-consumers that need image bytes for a figure or table (e.g. for attaching to
-a working-memory record).
+Rasterize a bounding-box region of a single PDF page as a PNG or JPG image.
+Used by consumers that need image bytes for a figure or table (e.g. for
+attaching to a working-memory record).
 
-**Request:** JSON body
-```json
-{
-  "pdf_bytes": "<base64-encoded PDF>",
-  "page": 0,
-  "bbox": { "x0": 72.0, "y0": 100.0, "x1": 400.0, "y1": 300.0 },
-  "dpi": 144,
-  "max_dim_px": 2048
-}
-```
+**Request:** `multipart/form-data` (mirrors `/api/extract`).
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `pdf_bytes` | string (base64) | — | PDF data |
-| `page` | int | — | 0-indexed page number |
-| `bbox` | object | — | PDF point coordinates (1/72 inch). `x0<x1`, `y0<y1`, non-negative. Bbox is clipped to the page rect; entirely-outside bboxes return 400. |
+| `file` | file | — | PDF bytes (`application/pdf` part). |
+| `page` | int | — | **1-based** page number, matching `/api/extract`'s `page_number` convention. |
+| `x_min`, `y_min`, `x_max`, `y_max` | float | — | Bbox in PDF point coordinates (1/72 inch). `x_min<x_max`, `y_min<y_max`, non-negative. Bbox is clipped to the page rect; entirely-outside bboxes return 400. |
 | `dpi` | int | `144` | Render DPI. Must be in `[36, 600]`. |
-| `max_dim_px` | int | `2048` | If the rendered PNG's larger dimension exceeds this, the image is rendered at a proportionally lower scale. Must be in `[1, 8192]`. |
+| `format` | `png` \| `jpg` | `png` | Output image format. |
+| `max_dim_px` | int | `2048` | If the rendered image's larger dimension exceeds this, the image is rendered at a proportionally lower scale. Must be in `[1, 8192]`. |
 
-**Response:** `image/png` bytes. Image metadata is in response headers:
-- `X-Image-Width`, `X-Image-Height`: pixel dimensions
+**Response:** raw image bytes. `Content-Type` is `image/png` or `image/jpeg`
+depending on `format`. Image metadata is in response headers:
+- `X-Width-Px`, `X-Height-Px`: pixel dimensions
 - `X-DPI-Used`: effective DPI (lower than requested if downscaled)
-- `X-Page-Index`: 0-indexed page rendered
-- `X-Clipped-To-Page`: `true` if requested bbox extended past page bounds
+- `X-Page-Number`: 1-based page rendered (echoes the request)
+- `X-Clipped-To-Page`: `true` if the requested bbox extended past page bounds
 - `X-Downscaled`: `true` if the image was downscaled to fit `max_dim_px`
-- `X-Processing-Time-Ms`: processing time in milliseconds
+- `X-Render-Time-Ms`: server-side processing time in milliseconds
 
 **Errors:**
-- `400` invalid bbox / page / dpi / max_dim_px / base64
-- `422` malformed PDF
+- `400` invalid bbox / page / dpi / format / max_dim_px / oversized file
+- `422` malformed PDF or missing required multipart field
 - `5xx` PyMuPDF render failure
+
+**Breaking change in v0.3.0:** the prior JSON+base64 contract (with nested
+`bbox` and 0-indexed `page`) was removed. See ff-services-pymupdf#12.
 
 ### `POST /api/detect-text-layer`
 Check which pages have extractable text.

--- a/packages/client-ts/package.json
+++ b/packages/client-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebrandanalytics/pymupdf-worker-client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TypeScript client (gRPC + HTTP) for FireFoundry PyMuPDF Processing Worker",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/client-ts/src/http-client.ts
+++ b/packages/client-ts/src/http-client.ts
@@ -2,32 +2,45 @@ import { z } from 'zod';
 
 // ---- Zod schemas ----
 
+/**
+ * Bounding box in PDF point coordinates (1/72 inch).
+ *
+ * Note: the prior 0.2.0 schema used {x0,y0,x1,y1}. The service now matches
+ * the rest of the FireFoundry ecosystem (DocProcLayoutClient, pymupdf
+ * extract responses) which use {x_min,y_min,x_max,y_max}.
+ */
 export const BBoxSchema = z.object({
-  x0: z.number(),
-  y0: z.number(),
-  x1: z.number(),
-  y1: z.number(),
+  x_min: z.number(),
+  y_min: z.number(),
+  x_max: z.number(),
+  y_max: z.number(),
 });
 export type BBox = z.infer<typeof BBoxSchema>;
 
 export const RenderRegionRequestSchema = z.object({
-  pdf_bytes: z.string().describe('Base64-encoded PDF data'),
-  page: z.number().int().describe('0-indexed page number'),
+  /** 1-based page number, matching `/api/extract`'s page_number convention. */
+  page: z.number().int().min(1).describe('1-based page number'),
   bbox: BBoxSchema,
   dpi: z.number().int().min(36).max(600).default(144),
+  format: z.enum(['png', 'jpg']).default('png'),
   max_dim_px: z.number().int().min(1).max(8192).default(2048),
 });
 export type RenderRegionRequest = z.input<typeof RenderRegionRequestSchema>;
 
 export interface RenderRegionResult {
+  /** Encoded image bytes (PNG or JPEG, per request `format`). */
+  image: Uint8Array;
+  /** Same bytes as `image`; kept for backwards-compat with 0.2.0 callers. */
   png: Uint8Array;
+  format: 'png' | 'jpg';
   widthPx: number;
   heightPx: number;
   dpiUsed: number;
-  pageIndex: number;
+  /** 1-based page number that was rendered. */
+  pageNumber: number;
   clippedToPage: boolean;
   downscaled: boolean;
-  processingTimeMs?: number;
+  renderTimeMs?: number;
 }
 
 export interface PyMuPDFHttpClientOptions {
@@ -55,7 +68,11 @@ export class PyMuPDFServiceError extends Error {
  *
  * The gRPC client (`PyMuPDFProcessorClient`) covers `extract` and
  * `detect_text_layer`. Binary-bearing endpoints like `render-region`,
- * which return raw `image/png`, live here.
+ * which return raw image bytes, live here.
+ *
+ * As of service v0.3.0, `/api/render-region` accepts multipart/form-data
+ * (matching the existing `/api/extract` pattern). The prior JSON+base64
+ * contract has been removed.
  */
 export class PyMuPDFHttpClient {
   private readonly baseUrl: string;
@@ -76,35 +93,42 @@ export class PyMuPDFHttpClient {
   }
 
   /**
-   * Render a bbox of a single PDF page as a PNG.
+   * Render a bbox of a single PDF page as an image.
    *
-   * @param input Either an already-base64 string + bbox, or pdf bytes that
-   *   will be base64-encoded for you.
+   * The PDF bytes are sent as a multipart file part named `file`, alongside
+   * the render parameters as separate form fields. This matches the contract
+   * implemented by `DocProcLayoutClient.renderRegion` in rag-agent-bundle.
    */
   async renderRegion(
-    input:
-      | RenderRegionRequest
-      | (Omit<RenderRegionRequest, 'pdf_bytes'> & { pdfBytes: Uint8Array }),
+    pdfBytes: Uint8Array,
+    params: RenderRegionRequest,
   ): Promise<RenderRegionResult> {
-    // Always build a fresh object so we never mutate the caller's input.
-    let prepared: Record<string, unknown>;
-    if ('pdfBytes' in input) {
-      const { pdfBytes, ...rest } = input;
-      prepared = { ...rest, pdf_bytes: encodeBase64(pdfBytes) };
-    } else {
-      prepared = { ...input };
-    }
+    const parsed = RenderRegionRequestSchema.parse(params);
 
-    const parsed = RenderRegionRequestSchema.parse(prepared);
+    const form = new FormData();
+    form.append(
+      'file',
+      new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' }),
+      'document.pdf',
+    );
+    form.append('page', String(parsed.page));
+    form.append('x_min', String(parsed.bbox.x_min));
+    form.append('y_min', String(parsed.bbox.y_min));
+    form.append('x_max', String(parsed.bbox.x_max));
+    form.append('y_max', String(parsed.bbox.y_max));
+    form.append('dpi', String(parsed.dpi));
+    form.append('format', parsed.format);
+    form.append('max_dim_px', String(parsed.max_dim_px));
 
+    const acceptHeader =
+      parsed.format === 'jpg' ? 'image/jpeg' : 'image/png';
     const res = await this.fetchImpl(`${this.baseUrl}/api/render-region`, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        Accept: 'image/png',
+        Accept: acceptHeader,
         ...this.defaultHeaders,
       },
-      body: JSON.stringify(parsed),
+      body: form,
     });
 
     if (!res.ok) {
@@ -127,14 +151,16 @@ export class PyMuPDFHttpClient {
 
     const buf = new Uint8Array(await res.arrayBuffer());
     return {
+      image: buf,
       png: buf,
-      widthPx: parseIntHeader(res.headers, 'x-image-width'),
-      heightPx: parseIntHeader(res.headers, 'x-image-height'),
+      format: parsed.format,
+      widthPx: parseIntHeader(res.headers, 'x-width-px'),
+      heightPx: parseIntHeader(res.headers, 'x-height-px'),
       dpiUsed: parseIntHeader(res.headers, 'x-dpi-used'),
-      pageIndex: parseIntHeader(res.headers, 'x-page-index'),
+      pageNumber: parseIntHeader(res.headers, 'x-page-number'),
       clippedToPage: res.headers.get('x-clipped-to-page') === 'true',
       downscaled: res.headers.get('x-downscaled') === 'true',
-      processingTimeMs: tryParseIntHeader(res.headers, 'x-processing-time-ms'),
+      renderTimeMs: tryParseIntHeader(res.headers, 'x-render-time-ms'),
     };
   }
 }
@@ -152,21 +178,4 @@ function tryParseIntHeader(headers: Headers, name: string): number | undefined {
   if (v == null) return undefined;
   const n = Number.parseInt(v, 10);
   return Number.isFinite(n) ? n : undefined;
-}
-
-function encodeBase64(bytes: Uint8Array): string {
-  // Prefer Node's Buffer when available; fall back to btoa.
-  const g = globalThis as unknown as {
-    Buffer?: { from(b: Uint8Array): { toString(enc: 'base64'): string } };
-    btoa?: (s: string) => string;
-  };
-  if (g.Buffer) {
-    return g.Buffer.from(bytes).toString('base64');
-  }
-  if (g.btoa) {
-    let s = '';
-    for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
-    return g.btoa(s);
-  }
-  throw new Error('No base64 encoder available (no Buffer, no btoa)');
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ff-services-pymupdf"
-version = "0.2.0"
+version = "0.3.0"
 description = "PyMuPDF-based PDF processing gRPC microservice"
 requires-python = ">=3.11"
 

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -20,6 +20,10 @@ from .renderers.region import (
     render_region,
 )
 
+SERVICE_VERSION = "0.3.0"
+ALLOWED_RENDER_FORMATS = {"png", "jpg"}
+RENDER_FORMAT_CONTENT_TYPES = {"png": "image/png", "jpg": "image/jpeg"}
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -39,28 +43,7 @@ class HealthResponse(BaseModel):
     """Response body for GET /health."""
     status: str = "ok"
     operations: List[str]
-    version: str = "0.2.0"
-
-
-class BBox(BaseModel):
-    """Bounding box in PDF point coordinates (1/72 inch)."""
-    x0: float
-    y0: float
-    x1: float
-    y1: float
-
-
-class RenderRegionRequest(BaseModel):
-    """Request body for POST /api/render-region."""
-    pdf_bytes: str = Field(..., description="Base64-encoded PDF data")
-    # No `ge` on page — let the renderer return 400 with a descriptive
-    # message instead of Pydantic's generic 422.
-    page: int = Field(..., description="0-indexed page number")
-    bbox: BBox
-    dpi: int = Field(144, ge=36, le=600, description="Target render DPI")
-    max_dim_px: int = Field(
-        2048, ge=1, le=8192, description="Max output dimension in pixels"
-    )
+    version: str = SERVICE_VERSION
 
 
 def create_app() -> FastAPI:
@@ -68,7 +51,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title="PyMuPDF Processing Service",
         description="PDF text extraction, table detection, and text layer analysis using PyMuPDF",
-        version="0.2.0",
+        version=SERVICE_VERSION,
     )
 
     backends: List[Backend] = [
@@ -92,7 +75,7 @@ def create_app() -> FastAPI:
         return HealthResponse(
             status="ok",
             operations=sorted(list(supported_operations)),
-            version="0.2.0",
+            version=SERVICE_VERSION,
         )
 
     @app.get("/ready")
@@ -199,17 +182,27 @@ def create_app() -> FastAPI:
             raise HTTPException(status_code=500, detail={"success": False, "error": str(e)})
 
     @app.post("/api/render-region")
-    async def render_region_endpoint(request: RenderRegionRequest):
-        """Render a bbox of a PDF page as a PNG image."""
+    async def render_region_endpoint(
+        file: UploadFile = File(...),
+        page: int = Form(..., description="1-based page number"),
+        x_min: float = Form(...),
+        y_min: float = Form(...),
+        x_max: float = Form(...),
+        y_max: float = Form(...),
+        dpi: int = Form(144),
+        format: str = Form("png"),
+        max_dim_px: int = Form(2048),
+    ):
+        """Render a bbox of a PDF page as a PNG or JPG image.
+
+        Mirrors the multipart contract of /api/extract. The `page` parameter
+        is 1-based (matching /api/extract's page_number convention). The
+        rendered image bytes are returned in the response body with metadata
+        in response headers (see X-Width-Px etc.).
+        """
         start_time = time.time()
 
-        try:
-            pdf_data = base64.b64decode(request.pdf_bytes, validate=True)
-        except Exception as e:
-            raise HTTPException(
-                status_code=400,
-                detail={"success": False, "error": f"Invalid base64 pdf_bytes: {e}"},
-            )
+        pdf_data = await file.read()
 
         config = get_config()
         max_bytes = config.extraction.max_file_size_mb * 1024 * 1024
@@ -222,21 +215,45 @@ def create_app() -> FastAPI:
                 },
             )
 
+        normalized_format = format.lower()
+        if normalized_format not in ALLOWED_RENDER_FORMATS:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "success": False,
+                    "error": (
+                        f"Invalid format: must be one of "
+                        f"{sorted(ALLOWED_RENDER_FORMATS)} (got {format!r})"
+                    ),
+                },
+            )
+
+        if page < 1:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "success": False,
+                    "error": f"Invalid page: must be 1-based (>= 1), got {page}",
+                },
+            )
+        page_index = page - 1
+
         logger.info(
             f"Render region request: size={len(pdf_data)} bytes, "
-            f"page={request.page}, bbox=({request.bbox.x0},{request.bbox.y0},"
-            f"{request.bbox.x1},{request.bbox.y1}), dpi={request.dpi}, "
-            f"max_dim_px={request.max_dim_px}"
+            f"page={page} (0-indexed {page_index}), "
+            f"bbox=({x_min},{y_min},{x_max},{y_max}), dpi={dpi}, "
+            f"format={normalized_format}, max_dim_px={max_dim_px}"
         )
 
         try:
-            png_bytes, meta = await asyncio.to_thread(
+            image_bytes, meta = await asyncio.to_thread(
                 render_region,
                 pdf_data,
-                request.page,
-                (request.bbox.x0, request.bbox.y0, request.bbox.x1, request.bbox.y1),
-                request.dpi,
-                request.max_dim_px,
+                page_index,
+                (x_min, y_min, x_max, y_max),
+                dpi,
+                max_dim_px,
+                normalized_format,
             )
         except MalformedPdfError as e:
             raise HTTPException(
@@ -257,15 +274,19 @@ def create_app() -> FastAPI:
 
         processing_time_ms = int((time.time() - start_time) * 1000)
         headers = {
-            "X-Image-Width": str(meta.width_px),
-            "X-Image-Height": str(meta.height_px),
+            "X-Width-Px": str(meta.width_px),
+            "X-Height-Px": str(meta.height_px),
             "X-DPI-Used": str(meta.dpi_used),
-            "X-Page-Index": str(meta.page_index),
+            "X-Page-Number": str(meta.page_index + 1),
             "X-Clipped-To-Page": "true" if meta.clipped_to_page else "false",
             "X-Downscaled": "true" if meta.downscaled else "false",
-            "X-Processing-Time-Ms": str(processing_time_ms),
+            "X-Render-Time-Ms": str(processing_time_ms),
         }
-        return Response(content=png_bytes, media_type="image/png", headers=headers)
+        return Response(
+            content=image_bytes,
+            media_type=RENDER_FORMAT_CONTENT_TYPES[normalized_format],
+            headers=headers,
+        )
 
     @app.post("/process")
     async def process_document(request: ProcessRequest) -> Dict[str, Any]:

--- a/src/renderers/region.py
+++ b/src/renderers/region.py
@@ -31,15 +31,21 @@ MIN_DPI = 36
 MAX_MAX_DIM_PX = 8192
 
 
+SUPPORTED_FORMATS = ("png", "jpg")
+# PyMuPDF accepts "jpeg" as the encode name; "jpg" is the public alias.
+_FORMAT_TO_PIXMAP_OUTPUT = {"png": "png", "jpg": "jpeg"}
+
+
 def render_region(
     pdf_data: bytes,
     page_index: int,
     bbox: Tuple[float, float, float, float],
     dpi: int = 144,
     max_dim_px: int = 2048,
+    output_format: str = "png",
 ) -> Tuple[bytes, RenderMetadata]:
     """
-    Render a bbox of a single PDF page as PNG bytes.
+    Render a bbox of a single PDF page as image bytes.
 
     Args:
         pdf_data: Raw PDF bytes.
@@ -49,13 +55,14 @@ def render_region(
         max_dim_px: If the rendered image's larger dimension exceeds this, the
             image is re-rendered at a proportionally lower DPI. Clamped to
             [1, MAX_MAX_DIM_PX].
+        output_format: "png" (default) or "jpg".
 
     Returns:
-        (png_bytes, metadata)
+        (image_bytes, metadata)
 
     Raises:
         MalformedPdfError: PDF cannot be parsed.
-        RegionRenderError: invalid bbox, page index, dpi, or max_dim_px.
+        RegionRenderError: invalid bbox, page index, dpi, max_dim_px, or format.
         RuntimeError: PyMuPDF raster operation failed.
     """
     x0, y0, x1, y1 = bbox
@@ -78,6 +85,10 @@ def render_region(
         )
     if page_index < 0:
         raise RegionRenderError(f"Invalid page_index: must be >= 0 (got {page_index})")
+    if output_format not in _FORMAT_TO_PIXMAP_OUTPUT:
+        raise RegionRenderError(
+            f"Invalid output_format: must be one of {SUPPORTED_FORMATS} (got {output_format!r})"
+        )
 
     try:
         doc = pymupdf.open(stream=pdf_data, filetype="pdf")
@@ -124,10 +135,13 @@ def render_region(
 
         dpi_used = int(round(scale * 72.0))
 
+        pixmap_output = _FORMAT_TO_PIXMAP_OUTPUT[output_format]
         try:
-            png_bytes = pix.tobytes("png")
+            image_bytes = pix.tobytes(pixmap_output)
         except Exception as e:
-            raise RuntimeError(f"PyMuPDF PNG encode failed: {e}") from e
+            raise RuntimeError(
+                f"PyMuPDF {output_format} encode failed: {e}"
+            ) from e
 
         metadata = RenderMetadata(
             width_px=pix.width,
@@ -137,6 +151,6 @@ def render_region(
             clipped_to_page=clipped_to_page,
             downscaled=downscaled,
         )
-        return png_bytes, metadata
+        return image_bytes, metadata
     finally:
         doc.close()

--- a/tests/test_render_region.py
+++ b/tests/test_render_region.py
@@ -1,6 +1,5 @@
 """Tests for the render-region functionality and HTTP endpoint."""
 
-import base64
 import io
 import struct
 
@@ -71,6 +70,20 @@ class TestRenderRegionUnit:
         assert meta.downscaled is False
         assert meta.width_px == w
         assert meta.height_px == h
+
+    def test_jpg_output(self):
+        pdf = make_test_pdf()
+        img, meta = render_region(
+            pdf, 0, (50.0, 50.0, 400.0, 450.0), dpi=144, output_format="jpg"
+        )
+        # JPEG SOI marker.
+        assert img[:2] == b"\xff\xd8"
+        assert meta.width_px > 0 and meta.height_px > 0
+
+    def test_invalid_output_format_rejected(self):
+        pdf = make_test_pdf()
+        with pytest.raises(RegionRenderError, match="Invalid output_format"):
+            render_region(pdf, 0, (50.0, 50.0, 100.0, 100.0), output_format="webp")
 
     def test_bbox_exceeds_page_is_clipped(self):
         """A bbox that extends past the page bounds should be clipped, not rejected."""
@@ -168,37 +181,68 @@ def client():
     return TestClient(create_app())
 
 
-class TestRenderRegionEndpoint:
-    def _body(self, pdf: bytes, **overrides):
-        body = {
-            "pdf_bytes": base64.b64encode(pdf).decode("ascii"),
-            "page": 0,
-            "bbox": {"x0": 50.0, "y0": 50.0, "x1": 400.0, "y1": 450.0},
-            "dpi": 144,
-            "max_dim_px": 2048,
-        }
-        body.update(overrides)
-        return body
+def _multipart(pdf: bytes, **fields):
+    """Build TestClient args for the multipart render-region contract.
 
+    Mirrors what `DocProcLayoutClient.renderRegion` sends from rag-agent-bundle:
+    file + page (1-based) + x_min/y_min/x_max/y_max + dpi + format + max_dim_px.
+    """
+    defaults = {
+        "page": "1",
+        "x_min": "50.0",
+        "y_min": "50.0",
+        "x_max": "400.0",
+        "y_max": "450.0",
+        "dpi": "144",
+        "format": "png",
+        "max_dim_px": "2048",
+    }
+    # Cast every override to str — multipart fields are always sent as strings.
+    for k, v in fields.items():
+        defaults[k] = str(v)
+    return {
+        "files": {"file": ("document.pdf", io.BytesIO(pdf), "application/pdf")},
+        "data": defaults,
+    }
+
+
+class TestRenderRegionEndpoint:
     def test_happy_path(self, client):
         pdf = make_test_pdf()
-        r = client.post("/api/render-region", json=self._body(pdf))
-        assert r.status_code == 200
+        r = client.post("/api/render-region", **_multipart(pdf))
+        assert r.status_code == 200, r.text
         assert r.headers["content-type"] == "image/png"
         assert r.content[:8] == b"\x89PNG\r\n\x1a\n"
-        assert int(r.headers["x-image-width"]) > 0
-        assert int(r.headers["x-image-height"]) > 0
-        assert r.headers["x-page-index"] == "0"
+        # Bundle-facing headers (DocProcLayoutClient reads these).
+        assert int(r.headers["x-width-px"]) > 0
+        assert int(r.headers["x-height-px"]) > 0
+        assert int(r.headers["x-render-time-ms"]) >= 0
+        # Page echoes as 1-based (matches request convention).
+        assert r.headers["x-page-number"] == "1"
         assert r.headers["x-clipped-to-page"] == "false"
         assert r.headers["x-downscaled"] == "false"
+
+    def test_jpg_format(self, client):
+        pdf = make_test_pdf()
+        r = client.post("/api/render-region", **_multipart(pdf, format="jpg"))
+        assert r.status_code == 200, r.text
+        assert r.headers["content-type"] == "image/jpeg"
+        # JPEG SOI marker.
+        assert r.content[:2] == b"\xff\xd8"
+
+    def test_invalid_format_returns_400(self, client):
+        pdf = make_test_pdf()
+        r = client.post("/api/render-region", **_multipart(pdf, format="webp"))
+        assert r.status_code == 400
+        assert "format" in r.json()["detail"]["error"].lower()
 
     def test_bbox_exceeds_page_clipped(self, client):
         pdf = make_test_pdf()
         r = client.post(
             "/api/render-region",
-            json=self._body(pdf, bbox={"x0": 0, "y0": 0, "x1": 10000, "y1": 10000}),
+            **_multipart(pdf, x_min=0, y_min=0, x_max=10000, y_max=10000),
         )
-        assert r.status_code == 200
+        assert r.status_code == 200, r.text
         assert r.headers["x-clipped-to-page"] == "true"
         assert r.content[:8] == b"\x89PNG\r\n\x1a\n"
 
@@ -206,102 +250,122 @@ class TestRenderRegionEndpoint:
         pdf = make_test_pdf()
         r = client.post(
             "/api/render-region",
-            json=self._body(pdf, bbox={"x0": 5000, "y0": 5000, "x1": 6000, "y1": 6000}),
+            **_multipart(pdf, x_min=5000, y_min=5000, x_max=6000, y_max=6000),
         )
         assert r.status_code == 400
         assert "does not intersect" in r.json()["detail"]["error"]
 
     def test_invalid_bbox_returns_400(self, client):
         pdf = make_test_pdf()
-        # x0 >= x1
+        # x_min >= x_max
         r = client.post(
             "/api/render-region",
-            json=self._body(pdf, bbox={"x0": 400, "y0": 50, "x1": 100, "y1": 200}),
+            **_multipart(pdf, x_min=400, y_min=50, x_max=100, y_max=200),
         )
         assert r.status_code == 400
         assert "x0" in r.json()["detail"]["error"]
 
     def test_page_out_of_range_returns_400(self, client):
         pdf = make_test_pdf(num_pages=2)
-        r = client.post("/api/render-region", json=self._body(pdf, page=10))
+        # 1-based page=10 → page_index=9, out of range for a 2-page doc.
+        r = client.post("/api/render-region", **_multipart(pdf, page=10))
         assert r.status_code == 400
         assert "out of range" in r.json()["detail"]["error"]
 
-    def test_negative_page_returns_400(self, client):
-        """Negative page is rejected by the renderer with a descriptive 400."""
+    def test_page_zero_returns_400(self, client):
+        """page=0 is invalid (1-based); endpoint rejects before calling renderer."""
         pdf = make_test_pdf()
-        r = client.post("/api/render-region", json=self._body(pdf, page=-1))
+        r = client.post("/api/render-region", **_multipart(pdf, page=0))
         assert r.status_code == 400
-        assert "page_index" in r.json()["detail"]["error"]
+        assert "1-based" in r.json()["detail"]["error"]
 
-    def test_dpi_out_of_range_returns_422(self, client):
-        """Pydantic catches dpi outside [36, 600] before the renderer runs."""
+    def test_negative_page_returns_400(self, client):
         pdf = make_test_pdf()
-        r = client.post("/api/render-region", json=self._body(pdf, dpi=10000))
-        assert r.status_code == 422
+        r = client.post("/api/render-region", **_multipart(pdf, page=-1))
+        assert r.status_code == 400
+        assert "1-based" in r.json()["detail"]["error"]
 
-    def test_max_dim_out_of_range_returns_422(self, client):
+    def test_dpi_out_of_range_returns_400(self, client):
+        """dpi outside [36, 600] reaches the renderer and is rejected with a 400."""
         pdf = make_test_pdf()
-        r = client.post("/api/render-region", json=self._body(pdf, max_dim_px=0))
-        assert r.status_code == 422
+        r = client.post("/api/render-region", **_multipart(pdf, dpi=10000))
+        assert r.status_code == 400
+        assert "dpi" in r.json()["detail"]["error"].lower()
+
+    def test_max_dim_out_of_range_returns_400(self, client):
+        pdf = make_test_pdf()
+        r = client.post("/api/render-region", **_multipart(pdf, max_dim_px=0))
+        assert r.status_code == 400
+        assert "max_dim_px" in r.json()["detail"]["error"]
 
     def test_malformed_pdf_returns_422(self, client):
         bad = b"this is definitely not a pdf"
-        body = {
-            "pdf_bytes": base64.b64encode(bad).decode("ascii"),
-            "page": 0,
-            "bbox": {"x0": 0, "y0": 0, "x1": 100, "y1": 100},
-        }
-        r = client.post("/api/render-region", json=body)
+        r = client.post(
+            "/api/render-region",
+            **_multipart(bad, x_min=0, y_min=0, x_max=100, y_max=100),
+        )
         assert r.status_code == 422
         assert "PDF" in r.json()["detail"]["error"]
-
-    def test_invalid_base64_returns_400(self, client):
-        body = {
-            "pdf_bytes": "%%%not-base64%%%",
-            "page": 0,
-            "bbox": {"x0": 0, "y0": 0, "x1": 100, "y1": 100},
-        }
-        r = client.post("/api/render-region", json=body)
-        assert r.status_code == 400
-        assert "base64" in r.json()["detail"]["error"].lower()
 
     def test_max_dim_downscale_via_endpoint(self, client):
         pdf = make_test_pdf()
         r = client.post(
             "/api/render-region",
-            json=self._body(
+            **_multipart(
                 pdf,
-                bbox={"x0": 0, "y0": 0, "x1": 612, "y1": 792},
+                x_min=0,
+                y_min=0,
+                x_max=612,
+                y_max=792,
                 dpi=144,
                 max_dim_px=300,
             ),
         )
-        assert r.status_code == 200
+        assert r.status_code == 200, r.text
         assert r.headers["x-downscaled"] == "true"
-        assert int(r.headers["x-image-width"]) <= 301
-        assert int(r.headers["x-image-height"]) <= 301
+        assert int(r.headers["x-width-px"]) <= 301
+        assert int(r.headers["x-height-px"]) <= 301
 
     def test_defaults_applied(self, client):
-        """dpi and max_dim_px default to 144 and 2048 when omitted."""
+        """dpi, format, and max_dim_px have defaults; only the bbox+file+page are required."""
         pdf = make_test_pdf()
-        body = {
-            "pdf_bytes": base64.b64encode(pdf).decode("ascii"),
-            "page": 0,
-            "bbox": {"x0": 50, "y0": 50, "x1": 400, "y1": 450},
+        files = {"file": ("document.pdf", io.BytesIO(pdf), "application/pdf")}
+        data = {
+            "page": "1",
+            "x_min": "50",
+            "y_min": "50",
+            "x_max": "400",
+            "y_max": "450",
         }
-        r = client.post("/api/render-region", json=body)
-        assert r.status_code == 200
+        r = client.post("/api/render-region", files=files, data=data)
+        assert r.status_code == 200, r.text
+        assert r.headers["content-type"] == "image/png"
         assert r.headers["x-dpi-used"] == "144"
         assert r.headers["x-downscaled"] == "false"
 
     def test_missing_required_field_422(self, client):
-        # Missing bbox
-        body = {
-            "pdf_bytes": base64.b64encode(make_test_pdf()).decode("ascii"),
-            "page": 0,
+        # Missing y_max
+        pdf = make_test_pdf()
+        files = {"file": ("document.pdf", io.BytesIO(pdf), "application/pdf")}
+        data = {
+            "page": "1",
+            "x_min": "50",
+            "y_min": "50",
+            "x_max": "400",
         }
-        r = client.post("/api/render-region", json=body)
+        r = client.post("/api/render-region", files=files, data=data)
+        assert r.status_code == 422
+
+    def test_missing_file_422(self, client):
+        # Multipart with no file part — FastAPI rejects with 422.
+        data = {
+            "page": "1",
+            "x_min": "50",
+            "y_min": "50",
+            "x_max": "400",
+            "y_max": "450",
+        }
+        r = client.post("/api/render-region", data=data)
         assert r.status_code == 422
 
 


### PR DESCRIPTION
## Summary

Fixes [#12](https://github.com/firebrandanalytics/ff-services-pymupdf/issues/12) — a critical API contract mismatch on the `POST /api/render-region` endpoint added in PR #10. The endpoint expected JSON+base64 but its only intended caller (`DocProcLayoutClient.renderRegion` in rag-agent-bundle) sends `multipart/form-data`. The first live ingestion saw **all 10 figures + 11 tables fail with HTTP 500 `UnicodeDecodeError`** — FastAPI tried to deserialize the multipart body as JSON.

Operator decision (per issue): **Option A — change the pymupdf endpoint to multipart**. No dual-contract support; the JSON+base64 path is removed entirely.

## Contract (matches `DocProcLayoutClient.renderRegion`)

`POST /api/render-region` — `multipart/form-data`:

| Field | Type | Default | Notes |
|---|---|---|---|
| `file` | file | — | PDF bytes, `application/pdf` |
| `page` | int | — | **1-based** (matches `/api/extract`'s `page_number`) |
| `x_min`, `y_min`, `x_max`, `y_max` | float | — | PDF point coords |
| `dpi` | int | `144` | |
| `format` | `png`\|`jpg` | `png` | |
| `max_dim_px` | int | `2048` | |

Response: raw image bytes (`image/png` or `image/jpeg`), metadata in headers (`X-Width-Px`, `X-Height-Px`, `X-DPI-Used`, `X-Page-Number`, `X-Clipped-To-Page`, `X-Downscaled`, `X-Render-Time-Ms`).

## Bundle-side compatibility

`DocProcLayoutClient.renderRegion` was unchanged in this PR. Its `FormData` now lands on a server that actually parses it:

```ts
form.append("file", new Blob([pdfBuffer], ...), "document.pdf");
form.append("page", String(params.page));      // 1-based
form.append("x_min", ...); form.append("y_min", ...);
form.append("x_max", ...); form.append("y_max", ...);
form.append("dpi", String(params.dpi ?? 144));
form.append("format", params.format ?? "png");
form.append("max_dim_px", String(params.maxDimPx ?? 2048));
```

And the response headers `x-width-px` / `x-height-px` / `x-render-time-ms` (which the bundle reads but the old server never emitted) are now produced.

## Page indexing

`IngestionPipelineV2` Stage 7.5 calls `renderRegion({ page: figure.physical_page + 1, ... })` — converting 0-based physical index to 1-based for the API. The endpoint now accepts 1-based and converts to 0-based when calling the internal `render_region(page_index=...)`. Verified against `IngestionPipelineV2.ts:962, 991`.

## Breaking changes (v0.2.0 → v0.3.0)

- `/api/render-region` request body is now `multipart/form-data` (was JSON+base64).
- Bbox field names: `x_min`/`y_min`/`x_max`/`y_max` (was `x0`/`y0`/`x1`/`y1`).
- Page is 1-based (was 0-indexed).
- Response headers renamed: `X-Width-Px` (was `X-Image-Width`), `X-Height-Px` (was `X-Image-Height`), `X-Render-Time-Ms` (was `X-Processing-Time-Ms`), `X-Page-Number` 1-based (was `X-Page-Index` 0-based).
- TS client `BBoxSchema` uses `x_min`/`y_min`/`x_max`/`y_max`. `RenderRegionRequest` no longer has `pdf_bytes`; PDF bytes are now passed as the first positional `Uint8Array` argument.

No external consumer other than rag-agent-bundle's `DocProcLayoutClient`, and that one is already on the multipart side.

## Test plan
- [x] `pytest -q` — 87 passed, 0 failed (33 in `test_render_region.py`).
- [x] `tsc --noEmit` on `packages/client-ts` — clean.
- [x] PNG happy path, JPG happy path, downscale path, bbox-clipping path, malformed-PDF, invalid format, page=0/negative, dpi out-of-range, max_dim_px out-of-range, missing required field, missing file — all covered with multipart requests.
- [ ] Image needs to be built+deployed (`ff-services-pymupdf:0.3.0`) before fix is live in any environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)